### PR TITLE
Bump bitstring version to an installable one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bitstring==3.1.3
+bitstring==3.1.4


### PR DESCRIPTION
Error at current version:

```
$ pip install -r requirements.txt 
Collecting bitstring==3.1.3 (from -r requirements.txt (line 1))
Could not find a version that satisfies the requirement bitstring==3.1.3 (from -r requirements.txt (line 1)) (from versions: 0.3.2, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.5.0, 0.5.1, 0.5.2, 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.0, 1.3.0, 2.0.0b1, 2.0.1b2, 2.0.2, 2.0.3, 2.1.0, 2.1.1, 2.2.0, 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2, 3.1.4)
No matching distribution found for bitstring==3.1.3 (from -r requirements.txt (line 1))
```
